### PR TITLE
Add xFeat+Steerers

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ All the matchers can run on GPU, and most of them can run both on GPU or CPU. A 
 | MASt3R (ArXiv '24) | [Official](https://github.com/naver/mast3r?tab=readme-ov-file) | [arxiv](https://arxiv.org/abs/2406.09756) | 0.699 | -- |
 | Efficient-LoFTR (CVPR '24) | [Official](https://github.com/zju3dv/efficientloftr) | [pdf](https://zju3dv.github.io/efficientloftr/files/EfficientLoFTR.pdf) | 0.1026 | 2.117 |
 | OmniGlue (CVPR '24) | [Official](https://github.com/google-research/omniglue) | [arxiv](https://arxiv.org/abs/2405.12979) | ❌ | 6.351 |
-| xFeat-Steerers | [Official](https://github.com/verlab/accelerated_features/issues/32) | -- | 0.027 | 0.124 | 
+| xFeat-Steerers | [Official](https://github.com/verlab/accelerated_features/issues/32) | -- | -- | 0.124 | 
 | xFeat (CVPR '24) | [Official](https://github.com/verlab/accelerated_features) | [arxiv](https://arxiv.org/abs/2404.19174) | 0.027 | 0.048 | 
 | GIM (ICLR '24) | [Official](https://github.com/xuelunshen/gim?tab=readme-ov-file) | [arxiv](https://arxiv.org/abs/2402.11095)  |  0.077 (+LG) /  1.627 (+DKMv3) | 5.321 (+LG) /  20.301 (+DKMv3) |
 | RoMa / Tiny-RoMa (CVPR '24) | [Official](https://github.com/Parskatt/RoMa) | [arxiv](https://arxiv.org/abs/2305.15404) |  0.453 / 0.0456 |  18.950 |

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ You can choose any of the following methods (input to `get_matcher()`):
 
 **Dense**: ```roma, tiny-roma, dust3r, mast3r```
 
-**Semi-dense**: ```loftr, eloftr, se2loftr, aspanformer, matchformer, xfeat-star```
+**Semi-dense**: ```loftr, eloftr, se2loftr, aspanformer, matchformer, xfeat-star, xfeat-star-steerers```
 
-**Sparse**: ```[sift, superpoint, disk, aliked, dedode, doghardnet, gim, xfeat]-lg, dedode, steerers, dedode-kornia, [sift, orb, doghardnet]-nn, patch2pix, superglue, r2d2, d2net,  gim-dkm, xfeat, omniglue, [dedode, xfeat, aliked]-subpx, [sift, superpoint]-sphereglue```
+**Sparse**: ```[sift, superpoint, disk, aliked, dedode, doghardnet, gim, xfeat]-lg, dedode, steerers, xfeat-steerers, dedode-kornia, [sift, orb, doghardnet]-nn, patch2pix, superglue, r2d2, d2net,  gim-dkm, xfeat, omniglue, [dedode, xfeat, aliked]-subpx, [sift, superpoint]-sphereglue```
 
 > [!TIP]
 > You can pass a list of matchers, i.e. `get_matcher([xfeat, tiny-roma])` to run both matchers and concatenate their keypoints. 
@@ -163,6 +163,7 @@ All the matchers can run on GPU, and most of them can run both on GPU or CPU. A 
 | MASt3R (ArXiv '24) | [Official](https://github.com/naver/mast3r?tab=readme-ov-file) | [arxiv](https://arxiv.org/abs/2406.09756) | 0.699 | -- |
 | Efficient-LoFTR (CVPR '24) | [Official](https://github.com/zju3dv/efficientloftr) | [pdf](https://zju3dv.github.io/efficientloftr/files/EfficientLoFTR.pdf) | 0.1026 | 2.117 |
 | OmniGlue (CVPR '24) | [Official](https://github.com/google-research/omniglue) | [arxiv](https://arxiv.org/abs/2405.12979) | ❌ | 6.351 |
+| xFeat-Steerers | [Official](https://github.com/verlab/accelerated_features/issues/32) | -- | 0.027 | 0.124 | 
 | xFeat (CVPR '24) | [Official](https://github.com/verlab/accelerated_features) | [arxiv](https://arxiv.org/abs/2404.19174) | 0.027 | 0.048 | 
 | GIM (ICLR '24) | [Official](https://github.com/xuelunshen/gim?tab=readme-ov-file) | [arxiv](https://arxiv.org/abs/2402.11095)  |  0.077 (+LG) /  1.627 (+DKMv3) | 5.321 (+LG) /  20.301 (+DKMv3) |
 | RoMa / Tiny-RoMa (CVPR '24) | [Official](https://github.com/Parskatt/RoMa) | [arxiv](https://arxiv.org/abs/2305.15404) |  0.453 / 0.0456 |  18.950 |

--- a/matching/__init__.py
+++ b/matching/__init__.py
@@ -47,6 +47,8 @@ available_models = [
     "xfeat",
     "xfeat-star",
     "xfeat-lg",
+    "xfeat-steerers",
+    "xfeat-star-steerers",
     "dedode-lg",
     "gim-dkm",
     "gim-lg",
@@ -199,13 +201,21 @@ def get_matcher(matcher_name="sift-lg", device="cpu", max_num_keypoints=2048, *a
         return matching_toolbox.DogAffHardNNMatcher(device, max_num_keypoints=max_num_keypoints, *args, **kwargs)
 
     elif "xfeat" in matcher_name:
-        from matching.im_models import xfeat
+        if "steerers" in matcher_name:
+            from matching.im_models import xfeat_steerers
 
-        kwargs["mode"] = "semi-dense" if "star" in matcher_name else "sparse"
+            kwargs["mode"] = "semi-dense" if "star" in matcher_name else "sparse"
 
-        if matcher_name.removeprefix("xfeat").removeprefix("-") in ["lg", "lightglue", "lighterglue"]:
-            kwargs["mode"] = "lighterglue"
-        return xfeat.xFeatMatcher(device, max_num_keypoints=max_num_keypoints, *args, **kwargs)
+            return xfeat_steerers.xFeatSteerersMatcher(device, max_num_keypoints, *args, **kwargs)
+        
+        else:
+            from matching.im_models import xfeat
+
+            kwargs["mode"] = "semi-dense" if "star" in matcher_name else "sparse"
+
+            if matcher_name.removeprefix("xfeat").removeprefix("-") in ["lg", "lightglue", "lighterglue"]:
+                kwargs["mode"] = "lighterglue"
+            return xfeat.xFeatMatcher(device, max_num_keypoints=max_num_keypoints, *args, **kwargs)
 
     elif matcher_name == "dedode-lg":
         from matching.im_models import kornia

--- a/matching/im_models/xfeat_steerers.py
+++ b/matching/im_models/xfeat_steerers.py
@@ -1,0 +1,86 @@
+import torch
+from torchvision.datasets.utils import download_file_from_google_drive
+
+from matching import BaseMatcher, WEIGHTS_DIR
+
+
+class xFeatSteerersMatcher(BaseMatcher):
+    steer_permutations = [
+        torch.arange(64).reshape(4, 16).roll(k, dims=0).reshape(64)
+        for k in range(4)
+    ]
+    weights_gdrive_id = "1nzYg4dmkOAZPi4sjOGpQnawMoZSXYXHt"
+    weights_path = WEIGHTS_DIR.joinpath("xfeat_perm_steer.pth")
+
+    def __init__(self, device="cpu", max_num_keypoints=4096, mode="sparse", *args, **kwargs):
+        super().__init__(device, **kwargs)
+        if mode not in ["sparse", "semi-dense"]:
+            raise ValueError(f'unsupported mode for xfeat: {self.mode}. Must choose from ["sparse", "semi-dense"]')
+
+        self.model = torch.hub.load("verlab/accelerated_features", "XFeat", pretrained=False, top_k=max_num_keypoints)
+        self.download_weights()
+        self.model.to(device)
+        self.max_num_keypoints = max_num_keypoints
+        self.mode = mode
+        self.min_cossim = kwargs.get("min_cossim", 0.9)
+        self.steer_permutations = [perm.to(device) for perm in self.steer_permutations]
+
+    def download_weights(self):
+        if not self.weights_path.exists():
+            download_file_from_google_drive(self.weights_gdrive_id, root=WEIGHTS_DIR, filename="xfeat_perm_steer.pth")
+
+        state_dict = torch.load(self.weights_path, map_location="cpu")
+        for k in list(state_dict):
+            state_dict["net." + k] = state_dict[k]
+            del state_dict[k]
+        self.model.load_state_dict(state_dict)
+
+    def _forward(self, img0, img1):
+        img0, img1 = self.model.parse_input(img0), self.model.parse_input(img1)
+
+        if self.mode == "semi-dense":
+            output0 = self.model.detectAndComputeDense(img0, top_k=self.max_num_keypoints)
+            output1 = self.model.detectAndComputeDense(img1, top_k=self.max_num_keypoints)
+
+            rot1to2 = 0
+            idxs_list = self.model.batch_match(output0["descriptors"], output1["descriptors"], min_cossim=self.min_cossim)
+            for r in range(1, 4):
+                new_idxs_list = self.model.batch_match(
+                    output0["descriptors"][..., self.steer_permutations[r]],
+                    output1["descriptors"],
+                    min_cossim=self.min_cossim
+                )
+                if len(new_idxs_list[0][0]) > len(idxs_list[0][0]):
+                    idxs_list = new_idxs_list
+                    rot1to2 = r
+
+            output0["descriptors"] = output1["descriptors"][..., self.steer_permutations[-rot1to2]]
+            matches = self.model.refine_matches(output0, output1, matches=idxs_list, batch_idx=0)
+            mkpts0, mkpts1 = matches[:, :2], matches[:, 2:]
+
+        else:
+            output0 = self.model.detectAndCompute(img0, top_k=self.max_num_keypoints)[0]
+            output1 = self.model.detectAndCompute(img1, top_k=self.max_num_keypoints)[0]
+            idxs0, idxs1 = self.model.match(output0["descriptors"], output1["descriptors"], min_cossim=self.min_cossim)
+            rot1to2 = 0
+            for r in range(1, 4):
+                new_idxs0, new_idxs1 = self.model.match(
+                    output0['descriptors'][..., self.steer_permutations[r]],
+                    output1['descriptors'],
+                    min_cossim=self.min_cossim
+                )
+                if len(new_idxs0) > len(idxs0):
+                    idxs0 = new_idxs0
+                    idxs1 = new_idxs1
+                    rot1to2 = r
+
+            mkpts0, mkpts1 = output0["keypoints"][idxs0], output1["keypoints"][idxs1]
+
+        return (
+            mkpts0,
+            mkpts1,
+            output0["keypoints"].squeeze(),
+            output1["keypoints"].squeeze(),
+            output0["descriptors"].squeeze(),
+            output1["descriptors"].squeeze(),
+        )


### PR DESCRIPTION
This PR adds xFeat+Steerers (sparse and semi-dense options) `xfeat-steerers` & `xfeat-star-steerers` which is an unpublished work in progress from https://github.com/verlab/accelerated_features/issues/32.

TODO: still needs gpu benchmarking, I've tested on cpu

Sample code rotating img0 by 90 deg

```python
import torch
from matching import get_matcher
from matching.viz import plot_matches

matcher = get_matcher('xfeat-steerers', device="cpu").eval()

img0 = matcher.load_image('assets/example_pairs/fresco/fsm.jpg', resize=256)
img0 = torch.rot90(img0, k=1, dims=(1, 2))
img1 = matcher.load_image('assets/example_pairs/fresco/sist_chapel.jpg', resize=256)
with torch.inference_mode():
    results = matcher(img0, img1)
plot_matches(img0, img1, results)
```

Samples:

- xfeat-steerers (sparse)
![xfeat-steerers](https://github.com/user-attachments/assets/4f102556-4a9b-4af9-9a6d-8c80caffb43e)

- xfeat-star-steerers (semi-dense)
![xfeat-star-steerers](https://github.com/user-attachments/assets/fc6ba287-7c9a-4290-8f0b-3bd7b8b02dd7)
