### PR TITLE
Fix sphereglue LFS budget issue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -45,7 +45,7 @@
 	url = https://github.com/KimSinjeong/keypt2subpx.git
 [submodule "matching/third_party/SphereGlue"]
 	path = matching/third_party/SphereGlue
-	url = https://github.com/vishalsharbidar/SphereGlue
+	url = https://github.com/alexstoken/SphereGlue.git
 [submodule "matching/third_party/affine-steerers"]
 	path = matching/third_party/affine-steerers
 	url = https://github.com/georg-bn/affine-steerers.git


### PR DESCRIPTION
SphereGlue upstream repo lost its LFS budget, so needed to fork, remove model weights, and redirect the submodule here toward the fork.

Original weights are still downloadable from the repo, just not available via LFS. 

Tested in colab.